### PR TITLE
add AVALANCHEGO_VERSION dockerfile arg

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -6,21 +6,21 @@ ARG AVALANCHEGO_VERSION
 
 ENV GOPATH=/go
 ENV PATH=$PATH:$GOPATH/bin
-ENV AVALANCHEGO_EXEC_PATH=$GOPATH/src/github.com/ava-labs/avalanchego/build/avalanchego
 ENV AVALANCHEGO_PLUGIN_PATH=$GOPATH/src/github.com/ava-labs/avalanchego/build/plugins
 
 # Install Node.js and npm using the official Node.js image
 RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && apt-get install -y nodejs
 
-# Clone the avalanchego repository
-RUN git clone -b $AVALANCHEGO_VERSION https://github.com/ava-labs/avalanchego.git $GOPATH/src/github.com/ava-labs/avalanchego
+WORKDIR /
 
-# Set the working directory to the cloned repository
-WORKDIR $GOPATH/src/github.com/ava-labs/avalanchego
+# # Download AvalancheGo Binary
+RUN curl -LJO https://github.com/ava-labs/avalanchego/releases/download/v1.10.5/avalanchego-linux-amd64-v1.10.5.tar.gz
+RUN tar -xzf avalanchego-linux-amd64-v1.10.5.tar.gz
+RUN mv avalanchego-v1.10.5 avalanchego
 
-# Build the avalanchego project using the sh script
-RUN ./scripts/build.sh
+ENV AVALANCHEGO_EXEC_PATH=/avalanchego/avalanchego
 
+# Install Avalanche Network Runner
 RUN curl -sSfL https://raw.githubusercontent.com/ava-labs/avalanche-network-runner/main/scripts/install.sh | sh -s
 
 ENV PATH ~/bin:$PATH

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,8 @@
 # Use a base image that includes both Go and Node.js, such as the official Go image
 FROM golang:latest
 
+# Derived from ./devcontainer.json
+ARG AVALANCHEGO_VERSION
 
 ENV GOPATH=/go
 ENV PATH=$PATH:$GOPATH/bin
@@ -11,7 +13,7 @@ ENV AVALANCHEGO_PLUGIN_PATH=$GOPATH/src/github.com/ava-labs/avalanchego/build/pl
 RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && apt-get install -y nodejs
 
 # Clone the avalanchego repository
-RUN git clone -b v1.10.5 https://github.com/ava-labs/avalanchego.git $GOPATH/src/github.com/ava-labs/avalanchego
+RUN git clone -b $AVALANCHEGO_VERSION https://github.com/ava-labs/avalanchego.git $GOPATH/src/github.com/ava-labs/avalanchego
 
 # Set the working directory to the cloned repository
 WORKDIR $GOPATH/src/github.com/ava-labs/avalanchego

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,10 @@
 	"name": "Avalanche-DevContainer",
 
 	"build": {
-		"dockerfile": "Dockerfile"
+		"dockerfile": "Dockerfile",
+		"args": {
+			"AVALANCHEGO_VERSION": "v1.10.5"
+		}
 	},
 	"runArgs": ["--network=host"],
 


### PR DESCRIPTION
This PR proposes the following change:

- As requested by @ceyonur in #27 , this PR modifies the version of AvalancheGo defined in the `Dockerfile` to now be an argument passed in by `devcontainer.json`, rather than a static value. 