### PR TITLE
Download AvalancheGo Binary instead of cloning repo and building

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,20 +4,19 @@ FROM golang:latest
 
 ENV GOPATH=/go
 ENV PATH=$PATH:$GOPATH/bin
-ENV AVALANCHEGO_EXEC_PATH=$GOPATH/src/github.com/ava-labs/avalanchego/build/avalanchego
 ENV AVALANCHEGO_PLUGIN_PATH=$GOPATH/src/github.com/ava-labs/avalanchego/build/plugins
 
 # Install Node.js and npm using the official Node.js image
 RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && apt-get install -y nodejs
 
-# Clone the avalanchego repository
-RUN git clone -b v1.10.5 https://github.com/ava-labs/avalanchego.git $GOPATH/src/github.com/ava-labs/avalanchego
+WORKDIR /
 
-# Set the working directory to the cloned repository
-WORKDIR $GOPATH/src/github.com/ava-labs/avalanchego
+# # Build the avalanchego project using the sh script
+RUN curl -LJO https://github.com/ava-labs/avalanchego/releases/download/v1.10.5/avalanchego-linux-amd64-v1.10.5.tar.gz
+RUN tar -xzf avalanchego-linux-amd64-v1.10.5.tar.gz
+RUN mv avalanchego-v1.10.5 avalanchego
 
-# Build the avalanchego project using the sh script
-RUN ./scripts/build.sh
+ENV AVALANCHEGO_EXEC_PATH=/avalanchego/avalanchego
 
 RUN curl -sSfL https://raw.githubusercontent.com/ava-labs/avalanche-network-runner/main/scripts/install.sh | sh -s
 


### PR DESCRIPTION
Now we use the AvalancheGo Binary instead of pulling the binary and building it from source.

**Why merge this?**
This decreases the build time of the DevContainer dramatically

**Further Work**
Still need to get AvalancheGo Version from versions.sh
