### PR TITLE
Cleanup devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,23 +1,9 @@
-# Use a base image that includes both Go and Node.js, such as the official Go image
-FROM golang:1.21.7-bullseye
+ARG AVALANCHEGO_VERSION
+FROM avaplatform/avalanche-cli:latest as avalanche-cli
+FROM avaplatform/avalanchego:$AVALANCHEGO_VERSION as avalanchego
+FROM mcr.microsoft.com/devcontainers/base
 
-ENV GOPATH=/go
-ENV PATH=$PATH:$GOPATH/bin
-ENV AVALANCHEGO_EXEC_PATH=$GOPATH/src/github.com/ava-labs/avalanchego/build/avalanchego
-ENV AVALANCHEGO_PLUGIN_PATH=$GOPATH/src/github.com/ava-labs/avalanchego/build/plugins
-
-# Install Node.js and npm using the official Node.js image
-RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && apt-get install -y nodejs
-
-# Clone the avalanchego repository
-RUN git clone -b v1.11.3 https://github.com/ava-labs/avalanchego.git $GOPATH/src/github.com/ava-labs/avalanchego
-
-# Set the working directory to the cloned repository
-WORKDIR $GOPATH/src/github.com/ava-labs/avalanchego
-
-# Build the avalanchego project using the sh script
-RUN ./scripts/build.sh
+COPY --from=avalanchego /avalanchego/build /go/src/github.com/ava-labs/avalanchego/build
+COPY --from=avalanche-cli /avalanche /usr/local/bin/avalanche
 
 RUN curl -sSfL https://raw.githubusercontent.com/ava-labs/avalanche-network-runner/main/scripts/install.sh | sh -s
-
-ENV PATH ~/bin:$PATH

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,15 +4,29 @@
 	"name": "Avalanche-DevContainer",
 
 	"build": {
-		"dockerfile": "Dockerfile"
+		"dockerfile": "Dockerfile",
+		"args": {
+			"AVALANCHEGO_VERSION": "v1.11.3"
+		}
 	},
 	"runArgs": ["--network=host"],
+
+	"remoteEnv": {
+		"GOPATH": "/go",
+		"PATH": "${containerEnv:PATH}:${env:GOPATH}/bin:~/bin",
+		"AVALANCHEGO_EXEC_PATH": "${containerEnv:GOPATH}/src/github.com/ava-labs/avalanchego/build/avalanchego",
+		"AVALANCHEGO_PLUGIN_PATH": "${containerEnv:GOPATH}/src/github.com/ava-labs/avalanchego/build/plugins",
+		"PK": "56289e99c94b6912bfc12adc093c9b51124f0dc54ac7a766b2bc5ccf558d8027",
+		"KEYSTORE": "${containerWorkspaceFolder}/keystore"
+	},
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	"features": { 
 		"ghcr.io/devcontainers/features/github-cli:1": {
 			"version": "latest"
-		}
+		},
+		"ghcr.io/devcontainers/features/node:1": {},
+		"ghcr.io/devcontainers/features/go:1": {}
 	 },
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
@@ -30,7 +44,7 @@
 	"postCreateCommand": "bash scripts/build.sh",
 
 	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
-	// "remoteUser": "root"
+	"remoteUser": "root",
 
 	"workspaceMount": "source=${localWorkspaceFolder},target=/go/src/github.com/ava-labs/precompile-evm,type=bind",
 	"workspaceFolder": "/go/src/github.com/ava-labs/precompile-evm",

--- a/.devcontainer/genesis-example.json
+++ b/.devcontainer/genesis-example.json
@@ -10,6 +10,10 @@
     "petersburgBlock": 0,
     "istanbulBlock": 0,
     "muirGlacierBlock": 0,
+    "warpConfig": {
+      "blockTimestamp": 0,
+      "quorumNumerator": 67
+    },
     "feeConfig": {
       "gasLimit": 15000000,
       "minBaseFee": 25000000000,

--- a/README.md
+++ b/README.md
@@ -47,6 +47,27 @@ In `plugin/main.go` Subnet-EVM is already imported and ready to be Run from the 
 
 You can build your precompile and Subnet-EVM with `./scripts/build.sh`. This script builds Subnet-EVM, and your precompile together and generates a binary file. The binary file is compatible with AvalancheGo plugins.
 
+### Run
+
+You can run you Precompile-EVM by using Avalanche Network Runner
+
+```bash
+avalanche-network-runner server \
+--log-level debug \
+--port=":8080" \
+--grpc-gateway-port=":8081"
+```
+
+Then launch a Subnet with your custom VM:
+
+```bash
+  avalanche-network-runner control start \
+  --log-level debug \
+  --endpoint="0.0.0.0:8080" \
+  --number-of-nodes=5 \
+  --blockchain-specs '[{"vm_name": "subnetevm", "genesis": "./.devcontainer/genesis-example.json"}]'
+```
+
 ### Test
 
 You can create contract tests in `contracts/test` with the Hardhat test framework. These can be run by adding ginkgko test cases in `tests/precompile/solidity/suites.go` and a suitable genesis file in `tests/precompile/genesis`. You can install AvalancheGo binaries with `./scripts/install_avalanchego_release.sh` then run the tests with `./scripts/run_ginkgo.sh`


### PR DESCRIPTION
- Use binaries from dockerhub instead of building from source
- use DevContainer features for nodeJS and Golang
- set ENV variables in devcontainer.json
- Add argument for AvalancheGo version to Dockerfile and set it in Devcontainer.json