### PR TITLE
rm: ANR from Dockerfile

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -11,5 +11,3 @@ COPY --from=foundry /usr/local/bin/forge /usr/local/bin/forge
 COPY --from=foundry /usr/local/bin/cast /usr/local/bin/cast
 COPY --from=foundry /usr/local/bin/anvil /usr/local/bin/anvil
 COPY --from=foundry /usr/local/bin/chisel /usr/local/bin/chisel
-
-RUN curl -sSfL https://raw.githubusercontent.com/ava-labs/avalanche-network-runner/main/scripts/install.sh | sh -s

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ To effectively build, run, and test Precompile-EVM, the following is a (non-exha
 - Golang
 - Node.js
 - [AvalancheGo](https://github.com/ava-labs/avalanchego)
-- [Avalanche Network Runner](https://github.com/ava-labs/avalanche-network-runner)
 
 To get started easily, we provide a Dev Container specification, that can be used using GitHub Codespace or locally using Docker and VS Code. DevContainers are a concept that utilizes containerization (via Docker containers) to create consistent and isolated development environment. We can access this environment through VS code, which allows for the development experience to feel as if you were developing locally..
 


### PR DESCRIPTION
The Precompile-EVM course uses Avalanche CLI, we should remove ANR to make the container build faster