### PR TITLE
chore: update scripts

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,26 +8,26 @@ on:
       - "*"
   pull_request:
 
-env:
-  min_go_version: "~1.22.8"
-
 jobs:
   lint_test:
     name: Lint
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.min_go_version }}
-          check-latest: true
+          go-version-file: "go.mod"
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.56
+          version: v1.63
           working-directory: .
           args: --timeout 10m
           skip-pkg-cache: true
+      - name: go mod tidy
+        run: |
+          go mod tidy
+          git diff --exit-code
 
   unit_test:
     name: Golang Unit Tests (${{ matrix.os }})
@@ -35,13 +35,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, ubuntu-20.04, ubuntu-latest, windows-latest]
+        os: [macos-latest, ubuntu-22.04, ubuntu-latest, windows-latest]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.min_go_version }}
-          check-latest: true
+          go-version-file: "go.mod"
       - name: Set timeout on Windows # Windows UT run slower and need a longer timeout
         shell: bash
         if: matrix.os == 'windows-latest'
@@ -68,8 +67,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.min_go_version }}
-          check-latest: true
+          go-version-file: "go.mod"
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:

--- a/scripts/constants.sh
+++ b/scripts/constants.sh
@@ -6,9 +6,9 @@ GOPATH="$(go env GOPATH)"
 # Static compilation
 STATIC_LD_FLAGS=''
 if [ "${STATIC_COMPILATION:-}" = 1 ]; then
-    export CC=musl-gcc
-    command -v $CC || (echo $CC must be available for static compilation && exit 1)
-    STATIC_LD_FLAGS=' -extldflags "-static" -linkmode external '
+  export CC=musl-gcc
+  command -v $CC || (echo $CC must be available for static compilation && exit 1)
+  STATIC_LD_FLAGS=' -extldflags "-static" -linkmode external '
 fi
 
 # Set the CGO flags to use the portable version of BLST
@@ -16,3 +16,6 @@ fi
 # We use "export" here instead of just setting a bash variable because we need
 # to pass this flag to all child processes spawned by the shell.
 export CGO_CFLAGS="-O2 -D__BLST_PORTABLE__"
+
+# CGO_ENABLED is required for multi-arch builds.
+export CGO_ENABLED=1

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
-golangci-lint run --path-prefix=. --timeout 3m

--- a/scripts/run_ginkgo.sh
+++ b/scripts/run_ginkgo.sh
@@ -16,8 +16,6 @@ source "$ROOT_DIR_PATH"/scripts/versions.sh
 
 # Build ginkgo
 echo "building precompile.test"
-# to install the ginkgo binary (required for test build and run)
-go install -v github.com/onsi/ginkgo/v2/ginkgo@${GINKGO_VERSION}
 
 TEST_SOURCE_ROOT=$(pwd)
 

--- a/scripts/versions.sh
+++ b/scripts/versions.sh
@@ -1,7 +1,38 @@
 #!/usr/bin/env bash
 
-# Set up the versions to be used - populate ENV variables only if they are not already populated
-SUBNET_EVM_VERSION=${SUBNET_EVM_VERSION:-'v0.7.1'}
-# Don't export them as they're used in the context of other calls
-AVALANCHE_VERSION=${AVALANCHE_VERSION:-'v1.12.2'}
-GINKGO_VERSION=${GINKGO_VERSION:-'v2.2.0'}
+# Ignore warnings about variables appearing unused since this file is not the consumer of the variables it defines.
+# shellcheck disable=SC2034
+
+set_module_version_var() {
+  local env_var_name="$1"
+  local module_path="$2"
+
+  if [[ -z "$env_var_name" || -z "$module_path" ]]; then
+    echo "Usage: set_module_version_var <ENV_VAR_NAME> <GO_MODULE_PATH>"
+    return 1
+  fi
+
+  # Check if the environment variable is already set
+  if [[ -z "${!env_var_name:-}" ]]; then
+    # Get module details from go.mod
+    local module_details
+    module_details="$(go list -m "$module_path" 2>/dev/null)" || return 1
+
+    # Extract version from module details
+    local version
+    version="$(echo "$module_details" | awk '{print $2}')"
+
+    # If version is a pseudo-version (timestamp-hash format), extract the short hash
+    if [[ "$version" =~ ^v.*[0-9]{14}-[0-9a-f]{12}$ ]]; then
+      local module_hash
+      module_hash="$(echo "$version" | cut -d'-' -f3)"
+      version="${module_hash::8}"
+    fi
+
+    # Don't export them as they're used in the context of other calls
+    eval "$env_var_name=$version"
+  fi
+}
+
+set_module_version_var "SUBNET_EVM_VERSION" "github.com/ava-labs/subnet-evm"
+set_module_version_var "AVALANCHE_VERSION" "github.com/ava-labs/avalanchego"


### PR DESCRIPTION
This pull request includes several changes to the GitHub Actions workflows and various scripts to improve the CI/CD process and build configurations. The most important changes include updating the Go version management, adding new environment variables for multi-arch builds, and refactoring version management in scripts.

Updates to GitHub Actions workflows:

* [`.github/workflows/tests.yml`](diffhunk://#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fL11-R43): Updated the Go version management to use `go.mod` instead of a hardcoded version, updated the `golangci-lint` version, and added a `go mod tidy` step. Also updated the OS matrix to include `ubuntu-22.04`. [[1]](diffhunk://#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fL11-R43) [[2]](diffhunk://#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fL71-R70)

Environment variables for multi-arch builds:

* [`scripts/constants.sh`](diffhunk://#diff-3c0381fa8951590efc60e6edcff45749a23ceb45ca7d2e0cfcf5e6232afc1595R19-R21): Added `CGO_ENABLED=1` to support multi-arch builds.

Removal of unnecessary scripts:

* [`scripts/lint.sh`](diffhunk://#diff-1698d50c9ce63ce31a1a027190c584c1192a31930366d90d242deb807b728cd5L1-L7): Removed the `lint.sh` script as it is no longer needed.

Refactoring version management in scripts:

* [`scripts/versions.sh`](diffhunk://#diff-c275e70e7b0f41a73996876c584ca0336077f3ce442f2a9b9088ca351f7d9a0eL3-R38): Added a `set_module_version_var` function to dynamically set module versions from `go.mod` and refactored existing version variables to use this function.

Other minor changes:

* [`scripts/run_ginkgo.sh`](diffhunk://#diff-4b15cda445549d6d10682f145fa81f65ccb47841c11a8df806ef1a1bf5b462b5L19-L20): Removed the installation of the `ginkgo` binary as it is no longer required.